### PR TITLE
Remove Vibecode Metro integration

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,5 @@
 const { getDefaultConfig } = require("expo/metro-config");
 const { withNativeWind } = require("nativewind/metro");
-const { withVibecodeMetro } = require("@vibecodeapp/sdk/metro");
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
@@ -8,10 +7,7 @@ const config = getDefaultConfig(__dirname);
 // Disable Watchman for file watching.
 config.resolver.useWatchman = false;
 
-// Configure asset and source extensions.
-const { assetExts, sourceExts } = config.resolver;
-
-// SVG transformer is configured by withVibecodeMetro
+// Configure transformer options.
 config.transformer = {
   ...config.transformer,
   getTransformOptions: async () => ({
@@ -22,11 +18,9 @@ config.transformer = {
   }),
 };
 
-// Configure resolver with SVG support and web platform mocking
+// Configure resolver with web platform mocking
 config.resolver = {
   ...config.resolver,
-  assetExts: assetExts.filter((ext) => ext !== "svg"),
-  sourceExts: [...sourceExts, "svg"],
   useWatchman: false,
   resolveRequest: (context, moduleName, platform) => {
     // Mock native-only modules on web
@@ -50,4 +44,4 @@ config.resolver = {
 };
 
 // Integrate NativeWind with the Metro configuration.
-module.exports = withNativeWind(withVibecodeMetro(config), { input: "./global.css" });
+module.exports = withNativeWind(config, { input: "./global.css" });


### PR DESCRIPTION
### Motivation
- Remove the project's dependency on the Vibecode Metro wrapper (`@vibecodeapp/sdk/metro`) to fix the runtime error and allow Metro to run like a standard Expo/React Native app.

### Description
- Update `metro.config.js` to remove the `require('@vibecodeapp/sdk/metro')` import and stop wrapping the config with `withVibecodeMetro`, while keeping `withNativeWind` and the resolver web-mocking logic intact and reverting custom SVG extension handling so Metro uses the standard transformer options.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d59ea97148330a0e1ef576212dd46)