### PR TITLE
Add react-native-get-random-values dependency to fix iOS build

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,5 @@
 const { getDefaultConfig } = require("expo/metro-config");
 const { withNativeWind } = require("nativewind/metro");
-const { withVibecodeMetro } = require("@vibecodeapp/sdk/metro");
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
@@ -8,10 +7,7 @@ const config = getDefaultConfig(__dirname);
 // Disable Watchman for file watching.
 config.resolver.useWatchman = false;
 
-// Configure asset and source extensions.
-const { assetExts, sourceExts } = config.resolver;
-
-// SVG transformer is configured by withVibecodeMetro
+// Configure transformer options.
 config.transformer = {
   ...config.transformer,
   getTransformOptions: async () => ({
@@ -22,11 +18,9 @@ config.transformer = {
   }),
 };
 
-// Configure resolver with SVG support and web platform mocking
+// Configure resolver with web platform mocking
 config.resolver = {
   ...config.resolver,
-  assetExts: assetExts.filter((ext) => ext !== "svg"),
-  sourceExts: [...sourceExts, "svg"],
   useWatchman: false,
   resolveRequest: (context, moduleName, platform) => {
     // Mock native-only modules on web
@@ -50,4 +44,4 @@ config.resolver = {
 };
 
 // Integrate NativeWind with the Metro configuration.
-module.exports = withNativeWind(withVibecodeMetro(config), { input: "./global.css" });
+module.exports = withNativeWind(config, { input: "./global.css" });

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-dom": "19.0.0",
         "react-native": "0.79.6",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-get-random-values": "^1.11.0",
         "react-native-keyboard-controller": "^1.19.2",
         "react-native-reanimated": "3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -7416,6 +7417,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -11538,6 +11545,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-get-random-values": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
+      "integrity": "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-base64-decode": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.56"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-get-random-values": "^1.11.0",
     "react-native-reanimated": "3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",


### PR DESCRIPTION
### Motivation
- Fix an iOS build failure caused by the `import "react-native-get-random-values"` in `index.ts` so the app can build on iOS and the UI loads correctly, while keeping the earlier Metro config update that removed the Vibecode wrapper.

### Description
- Add `react-native-get-random-values` to `dependencies` in `package.json` so the runtime import resolves on iOS. 
- Update `package-lock.json` to include the new package and its `fast-base64-decode` metadata so the lockfile remains consistent.
- Keep the Metro configuration change that removes the `@vibecodeapp/sdk/metro` wrapper and exports the config via `withNativeWind(config, { input: "./global.css" })` in `metro.config.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d59ea97148330a0e1ef576212dd46)