### PR TITLE
Fix poll response submission by memoizing handler and avoiding participant upsert conflicts

### DIFF
--- a/src/app/poll/[id].tsx
+++ b/src/app/poll/[id].tsx
@@ -70,10 +70,13 @@ function TimeSlotCard({
 }: TimeSlotCardProps) {
   const stats = getSlotStats(responses, slot.id);
 
-  const handleRespond = (availability: Availability) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onRespond(availability);
-  };
+  const handleRespond = useCallback(
+    (availability: Availability) => {
+      onRespond(availability);
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    },
+    [onRespond]
+  );
 
   return (
     <Animated.View

--- a/src/lib/use-database.ts
+++ b/src/lib/use-database.ts
@@ -392,11 +392,14 @@ export function useAddResponse() {
       const storedName = await getStoredDisplayName();
       const displayName = participantName || storedName || 'Anonymous';
 
-      await upsertParticipant({
-        pollId,
-        sessionId,
-        displayName,
-      });
+      const existingParticipant = await getParticipant(pollId, sessionId);
+      if (!existingParticipant) {
+        await upsertParticipant({
+          pollId,
+          sessionId,
+          displayName,
+        });
+      }
 
       await upsertResponse(pollId, slotId, sessionId, availability);
     },


### PR DESCRIPTION
### Motivation
- Ensure tapping Yes/Maybe/No reliably registers and persists a response by making the response callback run immediately and be stable across renders. 
- Prevent response submission from being blocked by unnecessary participant upserts by only inserting participants when they are missing.

### Description
- In `src/app/poll/[id].tsx` wrap the slot response handler in `useCallback` as `handleRespond`, call the provided `onRespond` before triggering haptics, and run haptics asynchronously with `void Haptics.impactAsync(...)` so the mutation runs immediately. 
- In `src/lib/use-database.ts` update the `useAddResponse` mutation to call `getParticipant(pollId, sessionId)` and only call `upsertParticipant(...)` when the participant does not already exist to avoid update conflicts delaying `upsertResponse`.

### Testing
- Ran `bun typecheck` which failed in this environment due to missing Expo/React Native typings and `expo/tsconfig.base`, so automated typechecking could not be completed. 
- Previously attempted `bun lint` (via `expo lint`) also could not run in this environment for the same missing dependency reasons, so no successful automated checks were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697dc76a61888330966409a515e35885)