### PR TITLE
Update PWA manifest — screenshots, theme color, description

### DIFF
--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,11 +1,11 @@
 {
   "name": "PlanToMeet",
   "short_name": "PlanToMeet",
-  "description": "Find the perfect time to meet. Create scheduling polls and share with friends.",
+  "description": "Find the perfect time to meet. Create scheduling polls and share with friends — no sign-up required.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#09090b",
-  "theme_color": "#09090b",
+  "background_color": "#05070C",
+  "theme_color": "#05070C",
   "orientation": "portrait-primary",
   "icons": [
     {
@@ -22,7 +22,29 @@
     }
   ],
   "categories": ["productivity", "utilities"],
-  "screenshots": [],
+  "screenshots": [
+    {
+      "src": "/screenshots/poll-voting.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow",
+      "label": "Vote on time slots — tap Yes, Maybe, or No"
+    },
+    {
+      "src": "/screenshots/poll-results.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow",
+      "label": "Best time chosen automatically from votes"
+    },
+    {
+      "src": "/screenshots/create-poll.png",
+      "sizes": "390x844",
+      "type": "image/png",
+      "form_factor": "narrow",
+      "label": "Create a poll in seconds — no account needed"
+    }
+  ],
   "prefer_related_applications": true,
   "related_applications": [
     {

--- a/web/public/screenshots/README.md
+++ b/web/public/screenshots/README.md
@@ -1,0 +1,25 @@
+# PWA Screenshots
+
+These screenshots are referenced in `/public/manifest.json` for the PWA install prompt on Chrome/Android.
+
+## Required Files
+
+| Filename | Dimensions | Content |
+|---|---|---|
+| `poll-voting.png` | 390×844px | Poll detail page showing time slots with Yes/Maybe/No vote buttons |
+| `poll-results.png` | 390×844px | Finalized poll showing the winning time slot |
+| `create-poll.png` | 390×844px | `/create` page with the poll creation form |
+
+## How to Capture
+
+1. Open Chrome DevTools → Toggle device toolbar → Set device to "iPhone 12 Pro" (390×844)
+2. Navigate to each page on `plantomeet.app`
+3. Take a screenshot (or use DevTools → Capture screenshot)
+4. Save at the correct filename in this directory
+
+## Notes
+
+- Dark background (#05070C) should be visible
+- No browser chrome (address bar) in the screenshots
+- Compress PNGs before committing (target: <200KB each)
+- Once App Store listing is live, update the `related_applications` URL in manifest.json


### PR DESCRIPTION
## Summary
- Adds 3 screenshot entries to `manifest.json` (required for Chrome/Android PWA install prompt)
- Fixes `background_color` and `theme_color` to match actual app background `#05070C` (was `#09090b`)
- Enhances short `description` to mention "no sign-up required"
- Creates `web/public/screenshots/README.md` with instructions for capturing and saving the actual screenshot files

## What's still needed (manual step)
The screenshots are declared in the manifest but the actual PNG files need to be captured:

| File | Where | Dimensions |
|---|---|---|
| `poll-voting.png` | `/poll/{any-open-poll-id}` | 390×844px |
| `poll-results.png` | `/poll/{finalized-poll-id}` | 390×844px |
| `create-poll.png` | `/create` | 390×844px |

Use Chrome DevTools → iPhone 12 Pro device frame → Capture screenshot.

## Test plan
- [ ] Install PWA on Android Chrome → install prompt shows screenshot carousel
- [ ] Check `theme_color` in browser tab matches dark background on iOS/Chrome
- [ ] PWA manifest validates at https://web.dev/measure

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)