### PR TITLE
feat(ios): activate Sentry crash reporting via conditional compilation

### DIFF
--- a/ios/PlanToMeet/App/PlanToMeetApp.swift
+++ b/ios/PlanToMeet/App/PlanToMeetApp.swift
@@ -6,9 +6,13 @@ import SwiftUI
 //    URL: https://github.com/getsentry/sentry-cocoa
 //    Version: 8.x.x
 // 2. Add SENTRY_DSN to ios/PlanToMeet/Secrets.xcconfig
-// 3. Uncomment the Sentry import and SentrySDK.start block below
 //
-// import Sentry
+// Once the Swift Package is added the #if canImport(Sentry) block below
+// activates automatically — no further code changes needed.
+
+#if canImport(Sentry)
+import Sentry
+#endif
 
 @main
 struct PlanToMeetApp: App {
@@ -34,17 +38,17 @@ struct PlanToMeetApp: App {
     }
 
     private func configureSentry() {
-        // Uncomment after adding Sentry Swift Package:
-        //
-        // guard let dsn = Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String,
-        //       !dsn.isEmpty else { return }
-        //
-        // SentrySDK.start { options in
-        //     options.dsn = dsn
-        //     options.environment = Bundle.main.object(forInfoDictionaryKey: "SENTRY_ENVIRONMENT") as? String ?? "production"
-        //     options.tracesSampleRate = 0.1
-        //     options.enableCrashHandler = true
-        //     options.enableSwiftAsyncStacktraces = true
-        // }
+        #if canImport(Sentry)
+        guard let dsn = Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String,
+              !dsn.isEmpty else { return }
+
+        SentrySDK.start { options in
+            options.dsn = dsn
+            options.environment = Bundle.main.object(forInfoDictionaryKey: "SENTRY_ENVIRONMENT") as? String ?? "production"
+            options.tracesSampleRate = 0.1
+            options.enableCrashHandler = true
+            options.enableSwiftAsyncStacktraces = true
+        }
+        #endif
     }
 }


### PR DESCRIPTION
## Summary
- Replaces the fully-commented Sentry scaffold in `PlanToMeetApp.swift` with `#if canImport(Sentry)` guards
- The `import Sentry` and `SentrySDK.start` block now compile and run automatically once the `sentry-cocoa` Swift Package is added in Xcode
- Zero code changes needed after package install — just add `SENTRY_DSN` to `Secrets.xcconfig`

## How to activate
1. In Xcode: **File → Add Package Dependencies** → `https://github.com/getsentry/sentry-cocoa` → Up to Next Major: `8.0.0`
2. Add to main app target only (not Messages/Clip)
3. Copy `Secrets.xcconfig.example` → `Secrets.xcconfig`, set `SENTRY_DSN`

## Test plan
- [ ] Build succeeds without Sentry package (conditional compilation guards empty block)
- [ ] After adding SPM package + DSN: `SentrySDK.start` fires on launch
- [ ] Test crash appears in Sentry dashboard within 60s of relaunch

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)