### PR TITLE
feat: reactions on finalized polls (iOS + web)

### DIFF
--- a/supabase/reactions.sql
+++ b/supabase/reactions.sql
@@ -1,0 +1,28 @@
+-- Reactions table for finalized polls.
+-- Run in Supabase SQL editor.
+
+CREATE TABLE IF NOT EXISTS reactions (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  poll_id     text        NOT NULL REFERENCES polls(id) ON DELETE CASCADE,
+  session_id  text        NOT NULL,
+  emoji       text        NOT NULL,
+  comment     text,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (poll_id, session_id)
+);
+
+ALTER TABLE reactions ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read reactions
+CREATE POLICY "reactions_select_all" ON reactions
+  FOR SELECT USING (true);
+
+-- Anyone can insert a reaction (one per session per poll via unique constraint)
+CREATE POLICY "reactions_insert" ON reactions
+  FOR INSERT WITH CHECK (true);
+
+-- Session owner can update their own reaction
+CREATE POLICY "reactions_update_self" ON reactions
+  FOR UPDATE
+  USING (session_id = (current_setting('request.jwt.claims', true)::jsonb ->> 'session_id'))
+  WITH CHECK (session_id = (current_setting('request.jwt.claims', true)::jsonb ->> 'session_id'));

--- a/web/src/app/poll/[id]/PollPageClient.tsx
+++ b/web/src/app/poll/[id]/PollPageClient.tsx
@@ -19,6 +19,7 @@ import { getSlotStats, Availability } from '@/lib/types'
 import { TimeSlotCard } from '@/components/TimeSlotCard'
 import { NameInput } from '@/components/NameInput'
 import { AddToCalendar } from '@/components/AddToCalendar'
+import { PollReactions } from '@/components/PollReactions'
 
 interface PollPageClientProps {
   pollId: string
@@ -246,9 +247,10 @@ export function PollPageClient({ pollId }: PollPageClientProps) {
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="mb-6"
+            className="mb-6 space-y-4"
           >
             <AddToCalendar poll={poll} slot={finalizedSlot} />
+            <PollReactions pollId={poll.id} participants={poll.participants} />
           </motion.div>
         )}
 

--- a/web/src/components/PollReactions.tsx
+++ b/web/src/components/PollReactions.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { fetchReactions, submitReaction } from '@/lib/api/reactions'
+import { getSessionId, getDisplayName } from '@/lib/utils'
+import type { Participant } from '@/lib/types'
+
+const PRESET_EMOJIS = ['🎉', '👍', '🙌', '🥳', '😍', '🔥']
+
+interface PollReactionsProps {
+  pollId: string
+  participants: Participant[]
+}
+
+export function PollReactions({ pollId, participants }: PollReactionsProps) {
+  const queryClient = useQueryClient()
+  const sessionId = typeof window !== 'undefined' ? getSessionId() : ''
+
+  const { data: reactions = [] } = useQuery({
+    queryKey: ['reactions', pollId],
+    queryFn: () => fetchReactions(pollId),
+    staleTime: 10_000,
+  })
+
+  const myReaction = reactions.find((r) => r.sessionId === sessionId)
+
+  const [selectedEmoji, setSelectedEmoji] = useState<string | null>(myReaction?.emoji ?? null)
+  const [comment, setComment] = useState(myReaction?.comment ?? '')
+
+  // Sync state if myReaction loads after mount
+  useEffect(() => {
+    if (myReaction) {
+      setSelectedEmoji(myReaction.emoji)
+      setComment(myReaction.comment ?? '')
+    }
+  }, [myReaction?.id])
+
+  const mutation = useMutation({
+    mutationFn: ({ emoji, comment }: { emoji: string; comment: string }) =>
+      submitReaction(pollId, sessionId, emoji, comment || null),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reactions', pollId] })
+      setSelectedEmoji(null)
+      setComment('')
+    },
+  })
+
+  const getParticipantName = (sid: string) =>
+    participants.find((p) => p.sessionId === sid)?.displayName || getDisplayName() || 'Anonymous'
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-4">
+      <h3 className="text-sm font-semibold text-text-primary">Reactions</h3>
+
+      {/* Emoji picker */}
+      <div className="flex gap-2 flex-wrap">
+        {PRESET_EMOJIS.map((emoji) => {
+          const isSelected = selectedEmoji === emoji
+          return (
+            <button
+              key={emoji}
+              onClick={() => setSelectedEmoji(isSelected ? null : emoji)}
+              className={`text-xl p-2 rounded-lg border transition-all ${
+                isSelected
+                  ? 'border-accent-blue/50 bg-accent-blue/15'
+                  : 'border-white/10 bg-white/5 hover:border-white/20'
+              }`}
+              aria-pressed={isSelected}
+              aria-label={`React with ${emoji}`}
+            >
+              {emoji}
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Comment + submit */}
+      {selectedEmoji && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+            placeholder="Add a comment (optional)"
+            maxLength={120}
+            className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-text-primary placeholder-text-tertiary outline-none focus:border-accent-blue/50 transition-all"
+          />
+          <button
+            onClick={() => mutation.mutate({ emoji: selectedEmoji, comment })}
+            disabled={mutation.isPending}
+            className="w-full rounded-lg py-2 text-sm font-semibold bg-accent-blue text-white hover:bg-accent-blue/90 disabled:opacity-50 transition-all"
+          >
+            {mutation.isPending
+              ? 'Posting…'
+              : myReaction
+              ? 'Update Reaction'
+              : 'Post Reaction'}
+          </button>
+        </div>
+      )}
+
+      {/* Existing reactions */}
+      {reactions.length > 0 && (
+        <div className="space-y-2 pt-2 border-t border-white/10">
+          {reactions.map((reaction) => (
+            <div key={reaction.id} className="flex items-start gap-3">
+              <span className="text-xl leading-none mt-0.5">{reaction.emoji}</span>
+              <div>
+                <p className="text-xs font-medium text-text-secondary">
+                  {getParticipantName(reaction.sessionId)}
+                </p>
+                {reaction.comment && (
+                  <p className="text-sm text-text-primary">{reaction.comment}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/lib/api/reactions.ts
+++ b/web/src/lib/api/reactions.ts
@@ -1,0 +1,30 @@
+import { supabaseRequest } from '../supabase'
+import { ReactionRow, Reaction, transformReaction } from '../types'
+
+export async function fetchReactions(pollId: string): Promise<Reaction[]> {
+  const rows = await supabaseRequest<ReactionRow[]>('reactions', {
+    params: {
+      select: '*',
+      poll_id: `eq.${pollId}`,
+      order: 'created_at.asc',
+    },
+  })
+  return (rows || []).map(transformReaction)
+}
+
+export async function submitReaction(
+  pollId: string,
+  sessionId: string,
+  emoji: string,
+  comment: string | null
+): Promise<void> {
+  const body: Record<string, string> = { poll_id: pollId, session_id: sessionId, emoji }
+  if (comment && comment.trim()) {
+    body.comment = comment.trim()
+  }
+  await supabaseRequest(`reactions?on_conflict=poll_id,session_id`, {
+    method: 'POST',
+    body,
+    headers: { Prefer: 'return=minimal,resolution=merge-duplicates' },
+  })
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -110,6 +110,36 @@ export function transformParticipant(row: ParticipantRow): Participant {
   }
 }
 
+// Reaction types
+export interface ReactionRow {
+  id: string
+  poll_id: string
+  session_id: string
+  emoji: string
+  comment: string | null
+  created_at: string
+}
+
+export interface Reaction {
+  id: string
+  pollId: string
+  sessionId: string
+  emoji: string
+  comment: string | null
+  createdAt: string
+}
+
+export function transformReaction(row: ReactionRow): Reaction {
+  return {
+    id: row.id,
+    pollId: row.poll_id,
+    sessionId: row.session_id,
+    emoji: row.emoji,
+    comment: row.comment,
+    createdAt: row.created_at,
+  }
+}
+
 // Slot statistics
 export interface SlotStats {
   available: number


### PR DESCRIPTION
## Summary
- After a poll is finalized, participants can post an emoji + optional comment reaction
- One reaction per participant per poll (upsert — can update emoji/comment)
- Both iOS and web show existing reactions with participant name, emoji, and comment

## Components
| Layer | What's new |
|---|---|
| **Supabase** | `reactions` table with `(poll_id, session_id)` unique constraint + RLS |
| **iOS API** | `ReactionRow`, `fetchReactions()`, `submitReaction()` in `SupabaseAPI` |
| **iOS UI** | Emoji picker + comment field + reactions list in `PollDetailScreen` (finalized only) |
| **Web API** | `fetchReactions()`, `submitReaction()` in `lib/api/reactions.ts` |
| **Web UI** | `<PollReactions>` component with React Query caching, renders under `<AddToCalendar>` |

## Test plan
- [ ] Run `supabase/reactions.sql` in Supabase SQL editor
- [ ] Open a finalized poll → reactions section appears below the calendar card
- [ ] Select emoji → comment input + Post button appear
- [ ] Post reaction → appears in list with your name
- [ ] Post again → reaction updates (upsert)
- [ ] Open same finalized poll from another session → see the reaction

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)